### PR TITLE
upgrade Spring Boot to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.0.RELEASE")
     }
 }
 
@@ -27,13 +27,6 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
-    testCompile('org.springframework.boot:spring-boot-starter-test') {
-//        exclude group: 'junit', module: 'junit'    // This is part of migration to junit5
-    }
-
-//TODO: Blocked on getting Junit5 to work with Spring
-//    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
-//    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-//    testCompile('org.junit.jupiter:junit-jupiter-params:5.2.0')
+    testCompile('org.springframework.boot:spring-boot-starter-test')
 }
 

--- a/src/test/java/spring/songs/AppTest.java
+++ b/src/test/java/spring/songs/AppTest.java
@@ -4,16 +4,14 @@
 package spring.songs;
 
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
 public class AppTest {
 
     @Test
     public void contextLoads() {
+
     }
 }


### PR DESCRIPTION
Apparently, Spring Boot 2.2.0, which is GA, has JUnit5 by default. 

https://blog.codeleak.pl/2019/09/spring-boot-testing-with-junit-5.html